### PR TITLE
Proxy requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,36 +1,18 @@
-var express = require('express');
-var app = express();
+var http = require('http');
 var https = require('https');
 
-var commonHeader = {'Content-Type': 'text/plain'};
-var array = ['org', 'code', 'section', 'studyyear', 'daytime', 'weekday', 'prof', 'breadth', 'online', 'waitlist', 'available', 'title']
+var port = 3000;
 
-var validate = function(request, response){
-  for (var obj in array){
-    var index = array[obj];
-    if (request.query[index] === undefined){
-      request.query[index] = "";
-    }
-    if (obj == array.length -1){
-      var str = "";
-      writeResponse = function(resp) {
-            resp.on('data', function (chunk) {
-                  str += chunk;
-            });
-            resp.on('end', function () {
-                  response.end(str);
-            });
-      }
-      https.request(`https://timetable.iit.artsci.utoronto.ca/api/courses?org=${request.query.org}&code=${request.query.code}&section=${request.query.section}&studyyear=${request.query.studyyear}&daytime=${request.query.daytime}&weekday=${request.query.weekday}&prof=${request.query.prof}&breadth=${request.query.breadth}&online=${request.query.online}&waitlist=${request.query.waitlist}&available=${request.query.available}&title=${request.query.title}`, writeResponse).end();
-    }
-  }
-}
+console.log('Listening on port ' + port);
 
-app.get("/courses", function (request, response){
-  response.writeHead(200, commonHeader);
-  validate(request, response, function(val){
-    response.end(val);
-  });
-})
-app.listen(process.env.PORT || 3000);
-console.log('Server running at http://127.0.0.1:3000/');
+http.createServer(function (client_request, client_response) {
+    console.log('REQUEST: {' + client_request.method + '} ' + client_request.url);
+    var proxy_request = https.request({
+        hostname: 'timetable.iit.artsci.utoronto.ca',
+        path: '/api' + client_request.url,
+        method: client_request.method
+    }, function (proxy_response) {
+        proxy_response.pipe(client_response, { end: true });
+    });
+    client_request.pipe(proxy_request, { end: true });
+}).listen(port);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "author": "Jesse Cordeiro",
   "license": "ISC",
   "dependencies": {
-    "express": "3.x"
   },
   "keywords": [
     "uoft",


### PR DESCRIPTION
Changed logic so that requests are simply proxied over to UofT's api.

Not sure whether you had something else in mind with this api, but from the logic you have for the single `/courses` endpoint, it seems that you're simply proxying the request
